### PR TITLE
sdreport: Fix bug #198

### DIFF
--- a/TMB/R/sdreport.R
+++ b/TMB/R/sdreport.R
@@ -259,7 +259,7 @@ sdreport <- function(obj,par.fixed=NULL,hessian.fixed=NULL,getJointPrecision=FAL
       epsilon <- rep(0,length(phi))
       names(epsilon) <- names(phi)
       parameters <- obj$env$parameters
-      parameters <- c(parameters, list(TMB_epsilon_ = epsilon) )
+      parameters$TMB_epsilon_ <- epsilon ## Appends to list without changing attributes
       doEpsilonMethod <- function(chunk = NULL) {
           if(!is.null(chunk)) { ## Only do *chunk*
               mapfac <- rep(NA, length(phi))


### PR DESCRIPTION
- Introduced in 6b38738460ed7b5b7e4ab4cc0859cd425d9ee5e1
- Attribute 'check.passed' was accidentally removed from parameter list.
- Caused bias.correction to break when parameter maps were in use.