### PR TITLE
add dbridge.hpp update TMB.hpp

### DIFF
--- a/TMB/inst/include/TMB.hpp
+++ b/TMB/inst/include/TMB.hpp
@@ -89,6 +89,7 @@ namespace CppAD{
 #include "tiny_ad/integrate/integrate.hpp"
 #include "Vectorize.hpp"
 #include "dnorm.hpp"   // harmless
+#include "dbridge.hpp" // harmless
 #include "lgamma.hpp"  // harmless
 #include "start_parallel.hpp"
 #include "tmb_core.hpp"

--- a/TMB/inst/include/dbridge.hpp
+++ b/TMB/inst/include/dbridge.hpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 Bruce Swihart
+// License: GPL-2
+
+/** \file
+    \brief Univariate bridge density (Wang & Louis (2003))
+    \ingroup R_style_distribution
+*/
+template<class Type>
+Type dbridge(Type x, Type phi, int give_log=0)
+{
+  Type logres;
+  logres=-log(Type(2*M_PI))+log(sin(Type(phi*M_PI)))-log(cosh(Type(phi*x))+cos(Type(phi*M_PI)));
+  //return 1/(2*M_PI)*sin(phi*M_PI)/(cosh(phi*x)+cos(phi*M_PI));
+  if(give_log)return logres; else return exp(logres);
+}
+VECTORIZE3_tti(dbridge)


### PR DESCRIPTION
This commit enables fitting logistic random intercept models where the random intercept has the bridge distribution allowing for a marginal logistic model after integrating out the random effects.

So instead of the "transformation trick" in one's .cpp file:

```
  /* Random Intercept Distribution - Begin*/
  nll -= sum(dnorm(u, Type(0.), Type(1.), true));
  vector<Type> unif = pnorm(vector<Type>(u),Type(0),Type(1));  /*get uniform*/
  // qbridge(p) is defined as 1/scale * log(sin(scale * pi * p)/sin(scale * pi * (1 - p)))
  Type scale  = 1./sqrt(1.+3./(M_PI*M_PI)*sd*sd);
  vector<Type> bridge = 1/scale * log(sin(scale * M_PI * unif)/sin(scale * M_PI * (1 - unif)));
  /* Random Intercept Distribution - End*/
```

One can just specify `dbridge`:

```
  /* Random Intercept Distribution - Begin*/
  nll -= sum(dbridge(u, Type(phi), true));
  /* Random Intercept Distribution - End*/
```


More:
https://cran.r-project.org/web/packages/bridgedist/index.html
Wang and Louis (2003) doi:10.1093/biomet/90.4.765

An implementation of the bridge distribution with logit-link in R. In Wang and Louis (2003) <doi:10.1093/biomet/90.4.765>, such a univariate bridge distribution was derived as the distribution of the random intercept that 'bridged' a marginal logistic regression and a conditional logistic regression. The conditional and marginal regression coefficients are a scalar multiple of each other. Such is not the case if the random intercept distribution was Gaussian.