### PR TITLE
oneStepPredict don't overwrite mapping of random effects

### DIFF
--- a/TMB/R/validation.R
+++ b/TMB/R/validation.R
@@ -199,6 +199,8 @@ oneStepPredict <- function(obj,
     names.all <- names(args$parameters)
     fix <- setdiff(names.all, names.random)
     map <- lapply(args$parameters[fix], function(x)factor(x*NA))
+    ran.in.map <- names.random[names.random %in% names(args$map)]
+    if(length(ran.in.map)) map <- c(map, args$map[ran.in.map]) # don't overwrite random effects mapping
     args$map <- map ## Overwrite map
     ## Find randomeffects character
     args$random <- names.random


### PR DESCRIPTION
Hello,

I think this is a simple fix to allow `oneStepPredict` to work with mapping of random effects. I have not done thorough testing of this change, but it did fix the issue for me. In my case, I was using map to not estimate one level of a random effect. This worked fine to estimate the model but then crashed calculating the OSA residuals, because the original mapping was overwritten.

It looks like there is another place that could use this change in `validation.R`, in the analogous section of `oneSamplePosterior`.

Let me know if you'd like a MWE or if I can help with further testing. Related to #108, although it seems that the OSA residuals work with parameter maps to me (and 108 could be closed).