### PR TITLE
Included double sqrt(int) function and template specializations of co…

### DIFF
--- a/TMB/inst/include/TMB.hpp
+++ b/TMB/inst/include/TMB.hpp
@@ -88,6 +88,58 @@ namespace CppAD{
   template <class T>
   bool isnan(const AD<T> &x)CSKIP({ return isnan(Value(x)); })
 }
+#ifdef __APPLE__
+/* Apple clang++ is very strictive casting int to double or float*/
+  double sqrt(const int& i)CSKIP({return double(i);})
+  namespace std{
+    template<>
+    complex<AD<double>> operator/(const complex<AD<double>>& x, const complex<AD<double>>& y){
+      AD<double> d    = (y.real()*y.real() + y.imag()*y.imag());
+      AD<double> real = (x.real()*y.real() + x.imag()*y.imag())/d;
+      AD<double> imag = (x.imag()*y.real() - x.real()*y.imag())/d;
+      return complex<AD<double>>(real, imag);
+    }
+
+    template<>
+    complex<AD<AD<double>>> operator/(const complex<AD<AD<double>>>& x, const complex<AD<AD<double>>>& y){
+      AD<AD<double>> d    = (y.real()*y.real() + y.imag()*y.imag());
+      AD<AD<double>> real = (x.real()*y.real() + x.imag()*y.imag())/d;
+      AD<AD<double>> imag = (x.imag()*y.real() - x.real()*y.imag())/d;
+      return complex<AD<AD<double>>>(real, imag);
+
+    }
+
+    template<>
+    complex<AD<AD<AD<double>>>> operator/(const complex<AD<AD<AD<double>>>>& x, const complex<AD<AD<AD<double>>>>& y){
+      AD<AD<AD<double>>> d    = (y.real()*y.real() + y.imag()*y.imag());
+      AD<AD<AD<double>>> real = (x.real()*y.real() + x.imag()*y.imag())/d;
+      AD<AD<AD<double>>> imag = (x.imag()*y.real() - x.real()*y.imag())/d;
+      return complex<AD<AD<AD<double>>>>(real, imag);
+    }
+  
+    template<>
+    complex<AD<double>> operator*(const complex<AD<double>>& x, const complex<AD<double>>& y){
+      AD<double> real = (x.real()*y.real() - x.imag()*y.imag());
+      AD<double> imag = (x.imag()*y.real() + x.real()*y.imag());
+      return complex<AD<double>>(real, imag);
+    }
+
+    template<>
+    complex<AD<AD<double>>> operator*(const complex<AD<AD<double>>>& x, const complex<AD<AD<double>>>& y){
+      AD<AD<double>> real = (x.real()*y.real() - x.imag()*y.imag());
+      AD<AD<double>> imag = (x.imag()*y.real() + x.real()*y.imag());
+      return complex<AD<AD<double>>>(real, imag);
+    }
+
+    template<>
+    complex<AD<AD<AD<double>>>> operator*(const complex<AD<AD<AD<double>>>>& x, const complex<AD<AD<AD<double>>>>& y){
+      AD<AD<AD<double>>> real = (x.real()*y.real() - x.imag()*y.imag());
+      AD<AD<AD<double>>> imag = (x.imag()*y.real() + x.real()*y.imag());
+      return complex<AD<AD<AD<double>>>>(real, imag);
+    }
+  }
+#endif
+
 #include "convert.hpp" // asSEXP, asMatrix, asVector
 #include "config.hpp"
 #include "atomic_math.hpp"


### PR DESCRIPTION
…mplex<> operator/ and complex<> operator* for Apple clang++ compiler with complex header from libc++ in order to compile VAST_v8_5_0.cpp

As  noted [here]<https://github.com/kaskr/adcomp/issues/297#issuecomment-584986159>, compilation of VAST_v*.cpp (eg VAST_v8_5_0.cpp) from [VAST]<https://github.com/James-Thorson-NOAA/VAST> on MacOS if Apple clang++ compiler is used. This problem is actually caused by the implementation of "complex<> operator/" in [complex header]<https://github.com/llvm/llvm-project/blob/master/libcxx/include/complex>. It requires conversion operator from AD to int as it has a piece of code  (line 679)
```
 __ilogbw = static_cast<int>(__logbw);
```
where _logbw to be AD.
In order to resolve this problem, a modification of definition of class CppAD::AD to include conversion operator from AD to int. 
As an alternative solution, I would like to propose to include template specializations of complex<> operator/ for AD<double>, AD<AD<double>> and AD<AD<AD<double>>> into TMB.hpp.
In addition Apple clang++ compiler often produce a compilation error if a piece of code.
```
sqrt(8)
```  
I would also like to propose to include a function
```
double sqrt(int)
```
into TMB.hpp

These additions are conditional to the macro __APPLE__  so that they will be enabled if and only if clang++ compiler is used on MacOS platform.
