### PR TITLE
Suggested option to use oneStepPredict(..., method="cdf" ) with delta-models

### DIFF
--- a/TMB/R/validation.R
+++ b/TMB/R/validation.R
@@ -311,13 +311,15 @@ oneStepPredict <- function(obj,
         pred$Fx <- 1 / ( 1 + exp(pred$nlcdf.lower - pred$nlcdf.upper) )
         pred$px <- 1 / ( exp(-pred$nlcdf.lower + pred$nll) +
                          exp(-pred$nlcdf.upper + pred$nll) )
-        if(discrete | length(deltaSupport)>0 ){
-            if(!is.null(seed)){
-                ## Restore RNG on exit:
-                Random.seed <- .GlobalEnv$.Random.seed
-                on.exit(.GlobalEnv$.Random.seed <- Random.seed)
-                set.seed(seed)
-            }
+        if(!is.null(seed)){
+            ## Restore RNG on exit:
+            Random.seed <- .GlobalEnv$.Random.seed
+            on.exit(.GlobalEnv$.Random.seed <- Random.seed)
+            set.seed(seed)
+        }
+        if(discrete){
+            U <- runif(nrow(pred))
+        } else if(length(deltaSupport)>0) {
             U <- ifelse( pred$obs %in% deltaSupport, runif(nrow(pred)), 0 )
         } else {
             U <- rep(0,nrow(pred))


### PR DESCRIPTION
Kasper and all,

As we briefly discussed by email, this pull request is my effort to provide a diff-file for a few changes that *seem* to provide capability for extending oneStepPredict(.) using method="cdf" to a delta-model, or other continuous distributions with a probability mass at a user-supplied set of locations (e.g., a zero-and-one inflated proportion for stomach content samples).  In this case, the user supplies `deltaSupport` (which is NULL by default), and the limit of deltaSupport = {all supported integers} should perform identically to `discrete=TRUE`

I very much do *not* understand the statistical theory underlying oneStepPredict(.), so please review this PR with caution!  However, in following the coding logic of method="cdf" there does not appear to be any fundamental distinction between discrete=TRUE and discrete=FALSE options in how they are handled on the R side, so it seems easy enough to simply provide the CDF appropriately in TMB and then evaluate as if its discrete=TRUE at those user-supplied probability-mass-locations, and discrete=FALSE at other locations where a continuous distribution applies.  This then simply requires that the user correctly code a CDF for the distribution on the TMB side, which is required of the method anyway.

I have done some limited testing of this modification for a delta-model without random effects, and in this case it appeared to behave as expected, i.e., give a uniform distribution for residuals for those observations of response = 0 under the correctly specified model.  However, I again emphasize that I cannot vouch for the statistical basis for the suggested modification; it's just based on my reading of its implementation.  

Thanks for your time in reviewing the suggestion.  