### PR TITLE
Thread gc

### DIFF
--- a/TMB/inst/include/TMB.hpp
+++ b/TMB/inst/include/TMB.hpp
@@ -67,6 +67,7 @@ void eigen_REprintf(const char* x);
    CppAD when compiling with '-std=c++11'. */
 #include <R.h>
 #include <Rinternals.h>
+#include "toggle_thread_safe_R.hpp"
 void eigen_REprintf(const char* x)CSKIP({REprintf(x);})
 
 #include "tmbutils/tmbutils.hpp"

--- a/TMB/inst/include/convert.hpp
+++ b/TMB/inst/include/convert.hpp
@@ -118,9 +118,10 @@ matrix<Type> asMatrix(SEXP x)
    R_xlen_t nr = Rf_nrows(x); // nrows is int
    R_xlen_t nc = Rf_ncols(x); // ncols is int
    matrix<Type> y(nr, nc);
+   double *p = REAL(x);
    for(R_xlen_t i=0; i<nr; i++)
      for(R_xlen_t j=0; j<nc; j++)
-       y(i, j) = Type(REAL(x)[i + nr * j]);
+       y(i, j) = Type(p[i + nr * j]);
    return y;
 }
 

--- a/TMB/inst/include/convert.hpp
+++ b/TMB/inst/include/convert.hpp
@@ -28,8 +28,8 @@ SEXP asSEXP(const matrix<Type> &a)
    SEXP val;
    PROTECT(val = Rf_allocMatrix(REALSXP, nr, nc));
    double *p = REAL(val);
-   for(R_xlen_t i=0; i<nr; i++)
-     for(R_xlen_t j=0; j<nc; j++)
+   for(R_xlen_t j=0; j<nc; j++)
+     for(R_xlen_t i=0; i<nr; i++)
        p[i + j * nr] = asDouble(a(i,j));
    UNPROTECT(1);
    return val;
@@ -119,8 +119,8 @@ matrix<Type> asMatrix(SEXP x)
    R_xlen_t nc = Rf_ncols(x); // ncols is int
    matrix<Type> y(nr, nc);
    double *p = REAL(x);
-   for(R_xlen_t i=0; i<nr; i++)
-     for(R_xlen_t j=0; j<nc; j++)
+   for(R_xlen_t j=0; j<nc; j++)
+     for(R_xlen_t i=0; i<nr; i++)
        y(i, j) = Type(p[i + nr * j]);
    return y;
 }

--- a/TMB/inst/include/dynamic_data.hpp
+++ b/TMB/inst/include/dynamic_data.hpp
@@ -110,7 +110,8 @@ namespace dynamic_data {
                                         "number of items to replace (%i) "
                                         "does not match replacement length (%i)",
                                         ty.size(), n);
-                             for (int i = 0; i<n; i++) ty[i] = REAL(data)[i];
+                             double* pdata = REAL(data);
+                             for (int i = 0; i<n; i++) ty[i] = pdata[i];
                              ,
                              // reverse
                              px[0] = 0;

--- a/TMB/inst/include/tmb_core.hpp
+++ b/TMB/inst/include/tmb_core.hpp
@@ -740,22 +740,21 @@ public:
      ADFun-object.
   */
   /** \brief Constructor which among other things gives a value to "theta" */
-  objective_function(SEXP data_, SEXP parameters_, SEXP report_)
+  objective_function(SEXP data, SEXP parameters, SEXP report) :
+    data(data), parameters(parameters), report(report), index(0)
   {
-    report=report_;
-    data=data_;
-    parameters=parameters_;
     /* Fill theta with the default parameters. 
        Pass R-matrices column major. */
-    theta.resize(nparms(parameters_));
-    index=0;
-    int counter=0;
-    SEXP obj=parameters_;
-    for(int i=0;i<Rf_length(obj);i++){
-      for(int j=0;j<Rf_length(VECTOR_ELT(obj,i));j++)
-	{
-	  theta[counter++]=Type(REAL(VECTOR_ELT(obj,i))[j]);
-	}
+    theta.resize(nparms(parameters));
+    int length_parlist = Rf_length(parameters);
+    for(int i = 0, counter = 0; i < length_parlist; i++) {
+      // x = parameters[[i]]
+      SEXP x = VECTOR_ELT(parameters, i);
+      int nx = Rf_length(x);
+      double* px = REAL(x);
+      for(int j = 0; j < nx; j++) {
+        theta[counter++] = Type( px[j] );
+      }
     }
     thetanames.resize(theta.size());
     for(int i=0;i<thetanames.size();i++)thetanames[i]="";

--- a/TMB/inst/include/toggle_thread_safe_R.hpp
+++ b/TMB/inst/include/toggle_thread_safe_R.hpp
@@ -1,0 +1,195 @@
+/** \file
+    \brief Override subset of R-API with thread safe versions.
+
+    This file is included by `TMB.hpp` if compiled with `_OPENMP`.  It
+    overrides a selected subset of the R-API with thread safe versions
+    (FIXME: Still some missing?).
+
+    If, for some reason, you want to undo the re-defines:
+
+    ```
+    #ifdef TMB_HAVE_THREAD_SAFE_R
+    #include <toggle_thread_safe_R.hpp>
+    #endif
+    ```
+
+    However, note that this is **not** recommended (the R macros are
+    often used from the user template through at least `DATA_STRUCT()`
+    and `DATA_UPDATE()`).
+
+    \note To minimize overhead one should use as few R-API calls as
+    possible, i.e. avoid doing REAL(x)[i] in a loop.
+*/
+
+#ifdef _OPENMP
+
+#ifndef TMB_HAVE_THREAD_SAFE_R
+
+inline SEXP Ts_getAttrib(SEXP x, SEXP y) {
+  SEXP ans;
+#pragma omp critical
+  {
+    ans = Rf_getAttrib(x, y);
+  }
+  return ans;
+}
+
+inline SEXP Ts_STRING_ELT(SEXP x, size_t i) {
+  SEXP ans;
+#pragma omp critical
+  {
+    ans = STRING_ELT(x, i);
+  }
+  return ans;
+}
+
+inline const char* Ts_CHAR(SEXP x) {
+  const char* ans;
+#pragma omp critical
+  {
+    ans = R_CHAR(x);
+  }
+  return ans;
+}
+
+inline SEXP Ts_VECTOR_ELT(SEXP x, size_t i) {
+  SEXP ans;
+#pragma omp critical
+  {
+    ans = VECTOR_ELT(x, i);
+  }
+  return ans;
+}
+
+inline R_len_t Ts_length(SEXP x) {
+  R_len_t ans;
+#pragma omp critical
+  {
+    ans = Rf_length(x);
+  }
+  return ans;
+}
+
+inline int* Ts_INTEGER(SEXP x) {
+  int* ans;
+#pragma omp critical
+  {
+    ans = INTEGER(x);
+  }
+  return ans;
+}
+
+inline double* Ts_REAL(SEXP x) {
+  double* ans;
+#pragma omp critical
+  {
+    ans = REAL(x);
+  }
+  return ans;
+}
+
+extern "C"
+inline void Ts_GetRNGstate() {
+#pragma omp critical
+  {
+    GetRNGstate();
+  }
+  // Wait for all threads to get to this point
+#pragma omp barrier
+}
+
+inline Rboolean Ts_isNumeric(SEXP x) {
+  Rboolean ans;
+#pragma omp critical
+  {
+    ans = Rf_isNumeric(x);
+  }
+  return ans;
+}
+
+inline int Ts_LENGTH(SEXP x) {
+  int ans;
+#pragma omp critical
+  {
+    ans = LENGTH(x);
+  }
+  return ans;
+}
+
+inline R_xlen_t Ts_XLENGTH(SEXP x) {
+  R_xlen_t ans;
+#pragma omp critical
+  {
+    ans = XLENGTH(x);
+  }
+  return ans;
+}
+
+inline SEXP Ts_install(const char *x) {
+  SEXP ans;
+#pragma omp critical
+  {
+    ans = Rf_install(x);
+  }
+  return ans;
+}
+
+inline SEXP Ts_findVar(SEXP x, SEXP y) {
+  SEXP ans;
+#pragma omp critical
+  {
+    ans = Rf_findVar(x, y);
+  }
+  return ans;
+}
+
+inline SEXP Ts_ENCLOS(SEXP x) {
+  SEXP ans;
+#pragma omp critical
+  {
+    ans = ENCLOS(x);
+  }
+  return ans;
+}
+
+/* --- Re-define ---------------------------------------------------------- */
+#define TMB_HAVE_THREAD_SAFE_R
+#define Rf_getAttrib   Ts_getAttrib
+#define STRING_ELT     Ts_STRING_ELT
+#undef  CHAR
+#define CHAR(x)        Ts_CHAR(x)
+#define VECTOR_ELT     Ts_VECTOR_ELT
+#define Rf_length      Ts_length
+#define INTEGER        Ts_INTEGER
+#define REAL           Ts_REAL
+#define GetRNGstate    Ts_GetRNGstate
+#define Rf_isNumeric   Ts_isNumeric
+#define LENGTH         Ts_LENGTH
+#define XLENGTH        Ts_XLENGTH
+#define Rf_install     Ts_install
+#define Rf_findVar     Ts_findVar
+#define ENCLOS         Ts_ENCLOS
+
+#else
+
+/* --- Un-define ---------------------------------------------------------- */
+#undef TMB_HAVE_THREAD_SAFE_R
+#undef Rf_getAttrib
+#undef STRING_ELT
+#undef  CHAR
+#define CHAR(x)        R_CHAR(x)
+#undef VECTOR_ELT
+#undef Rf_length
+#undef INTEGER
+#undef REAL
+#undef GetRNGstate
+#undef Rf_isNumeric
+#undef LENGTH
+#undef XLENGTH
+#undef Rf_install
+#undef Rf_findVar
+#undef ENCLOS
+
+#endif // TMB_HAVE_THREAD_SAFE_R
+
+#endif // _OPENMP


### PR DESCRIPTION
## Fix issues with gc() in multithread mode

It used to be that one could call read-only R-API functions such as `REAL()` in multithreading mode. With recent versions of R this is no longer the case, as it will mess up the garbage collector. This was demonstrated in #316 by 'Example 2'. The present PR solves these problems:

- Should solve #316  completely (in particular 'Example 2' now works without using `FreeADFun`).
- Should also solve problems reported [here](https://groups.google.com/g/tmb-users/c/4EZSIOJQF6Q) by @boennecd 
