### PR TITLE
add curl option to download suiteparse 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ unlock:
 ## Select version that match R's Matrix package
 SUITESPARSE = SuiteSparse-4.2.1
 METIS = metis-4.0.3
-WGET = curl -O
+WGET = curl -OL
 OS = $(shell uname)
 
 $(SUITESPARSE).tar.gz :

--- a/tmb_syntax/matrix_arrays.cpp
+++ b/tmb_syntax/matrix_arrays.cpp
@@ -48,6 +48,8 @@ Type objective_function<Type>::operator() ()
   Type v1_mincoeff = min(v1);    // minimum value in v1
   REPORT(v1_mincoeff);
 
+  matrix<Type> v2_matrix = v2.matrix(); //vector-to-matrix conversion
+  REPORT(v2_matrix);
 
   // Matrices =======================================================
 
@@ -112,9 +114,6 @@ Type objective_function<Type>::operator() ()
 
   vector<Type> m1_times_v1 = m1*v1;     // matrix-vector product
   REPORT(m1_times_v1);                  // R:  m1 %*% v1
-
-  matrix<Type> v2_matrix = v2.matrix(); //matrix-to-vector conversion
-  REPORT(v2_matrix);
 
  // Extracting parts of matrices
 


### PR DESCRIPTION
This happened to me installing metis on a Mac, guessing will be the same elsewhere. Plus some typo in matrix-array file.