### PR TITLE
Fix CPPAD_FRAMEWORK error after `make_metis_full`

### DIFF
--- a/TMB/inst/include/tmb_core.hpp
+++ b/TMB/inst/include/tmb_core.hpp
@@ -2517,7 +2517,7 @@ extern "C"
     PROTECT(ans = R_NilValue);
 #ifdef TMBAD_FRAMEWORK
     ans = mkString("TMBad");
-#elif  CPPAD_FRAMEWORK
+#elif defined(CPPAD_FRAMEWORK)
     ans = mkString("CppAD");
 #else
     ans = mkString("Unknown");


### PR DESCRIPTION
After running `make_metis_full`, compiling my package gives

```
In file included from /home/fuchs/fias/knguyen/R/x86_64-redhat-linux-gnu-library/3.6/TMB/include/TMB.hpp:181:0,
                 from GLI_GMRF_SPACE.cpp:1:
/home/fuchs/fias/knguyen/R/x86_64-redhat-linux-gnu-library/3.6/TMB/include/tmb_core.hpp:2520:23: error: #elif with no expression
 #elif  CPPAD_FRAMEWORK
                       ^
make: *** [GLI_GMRF_SPACE.o] Error 1
ERROR: compilation failed for package ‘dbtmb’
* removing ‘/home/fuchs/fias/knguyen/R/x86_64-redhat-linux-gnu-library/3.6/dbtmb’
* restoring previous ‘/home/fuchs/fias/knguyen/R/x86_64-redhat-linux-gnu-library/3.6/dbtmb’
```

due to not explicit `#elif  CPPAD_FRAMEWORK` evaluation I think. Change to `#elif defined(...)` solves it.