### PR TITLE
Use workaround to avoid Wunused-but-set-variable warnings

### DIFF
--- a/TMB/inst/include/cppad/local/cppad_assert.hpp
+++ b/TMB/inst/include/cppad/local/cppad_assert.hpp
@@ -2,6 +2,8 @@
 # ifndef CPPAD_CPPAD_ASSERT_INCLUDED
 # define CPPAD_CPPAD_ASSERT_INCLUDED
 
+# define CPPAD_UNUSED(x) ((void)(x))
+
 /* --------------------------------------------------------------------------
 CppAD: C++ Algorithmic Differentiation: Copyright (C) 2003-14 Bradley M. Bell
 

--- a/TMB/inst/include/cppad/ode_gear.hpp
+++ b/TMB/inst/include/cppad/ode_gear.hpp
@@ -487,6 +487,7 @@ void OdeGear(
 
 	// LU factor (and overwrite) the matrix A
 	int sign;
+	CPPAD_UNUSED(sign);
 	CppAD::vector<size_t> ip(n) , jp(n);
 	sign = LuFactor(ip, jp, A);
 	CPPAD_ASSERT_KNOWN(

--- a/TMB/inst/include/cppad/romberg_mul.hpp
+++ b/TMB/inst/include/cppad/romberg_mul.hpp
@@ -171,6 +171,7 @@ $end
 */
 
 # include <cppad/romberg_one.hpp>
+# include <cppad/local/cppad_assert.hpp>
 # include <cppad/check_numeric_type.hpp>
 # include <cppad/check_simple_vector.hpp>
 
@@ -275,6 +276,7 @@ public:
 		size_t i, j;
 		Float prod = 1;
 		size_t pow2 = 1;
+		CPPAD_UNUSED(pow2);
 		for(i = 0; i < m-1; i++)
 		{	prod *= (b[i] - a[i]);
 			for(j = 0; j < (n[i] - 1); j++)


### PR DESCRIPTION
Motivation: On MacOS with clang I get a lot of repeated warnings:
- `TMB/include/cppad/ode_gear.hpp:489:6: warning: variable 'sign' set but not used [-Wunused-but-set-variable]`
- `TMB/include/cppad/romberg_mul.hpp:277:10: warning: variable 'pow2' set but not used [-Wunused-but-set-variable]`

This workaround is using ideas from https://stackoverflow.com/questions/777261/avoiding-unused-variables-warnings-when-using-assert-in-a-release-build to avoid these warnings.