### PR TITLE
use Matrix API for SEXP->(cholmod_factor *) coercion

### DIFF
--- a/TMB/src/solve_subset.c
+++ b/TMB/src/solve_subset.c
@@ -45,6 +45,7 @@
 */
 #define USE_FC_LEN_T
 #include <R.h>
+#include <Rversion.h>
 #include <R_ext/BLAS.h>
 #include <R_ext/Lapack.h>
 #ifndef FCONE
@@ -66,15 +67,12 @@
 
 extern cholmod_common c; // See init.c
 
-/* Temporary fix until 'AS_CHM_FR__' is part of Matrix API.
-   In future replace code below by something like:
+#if !defined(R_MATRIX_PACKAGE_VERSION) || R_MATRIX_PACKAGE_VERSION < R_Version(1, 7, 1)
 
-#ifdef AS_CHM_FR__
-#undef AS_CHM_FR
-#define AS_CHM_FR AS_CHM_FR__
-#endif
+/* In Matrix < 1.7-1, the registered routine underlying AS_CHM_FR         */
+/* called cholmod_check_factor unconditionally, requiring much overhead.  */
+/* Hence, when TMB is compiled linking old Matrix, we redefine AS_CHM_FR. */
 
-*/
 #undef AS_CHM_FR
 #define AS_CHM_FR(x) tmb_as_cholmod_factor3((CHM_FR)alloca(sizeof(cholmod_factor)), x, FALSE)
 CHM_FR tmb_as_cholmod_factor3(CHM_FR ans, SEXP x, Rboolean do_check)
@@ -115,6 +113,8 @@ CHM_FR tmb_as_cholmod_factor3(CHM_FR ans, SEXP x, Rboolean do_check)
   }
   return ans;
 }
+
+#endif /* !defined(R_MATRIX_PACKAGE_VERSION) || ... */
 
 SEXP tmb_destructive_CHM_update(SEXP L, SEXP H, SEXP mult)
 {

--- a/TMB/src/solve_subset.c
+++ b/TMB/src/solve_subset.c
@@ -66,56 +66,6 @@
 
 extern cholmod_common c; // See init.c
 
-/* Temporary fix until 'AS_CHM_FR__' is part of Matrix API.
-   In future replace code below by something like:
-
-#ifdef AS_CHM_FR__
-#undef AS_CHM_FR
-#define AS_CHM_FR AS_CHM_FR__
-#endif
-
-*/
-#undef AS_CHM_FR
-#define AS_CHM_FR(x) tmb_as_cholmod_factor3((CHM_FR)alloca(sizeof(cholmod_factor)), x, FALSE)
-CHM_FR tmb_as_cholmod_factor3(CHM_FR ans, SEXP x, Rboolean do_check)
-{
-  int *type = INTEGER(GET_SLOT(x, install("type")));
-  SEXP tmp;
-  memset(ans, 0, sizeof(cholmod_factor)); /* zero the struct */
-  ans->itype = CHOLMOD_INT;	/* characteristics of the system */
-  ans->dtype = CHOLMOD_DOUBLE;
-  ans->z = (void *) NULL;
-  ans->xtype = CHOLMOD_REAL;
-  ans->ordering = type[0];	/* unravel the type */
-  ans->is_ll = (type[1] ? 1 : 0);
-  ans->is_super = (type[2] ? 1 : 0);
-  ans->is_monotonic = (type[3] ? 1 : 0);
-  SEXP Matrix_permSym = install("perm");
-  tmp = GET_SLOT(x, Matrix_permSym);
-  ans->minor = ans->n = LENGTH(tmp); ans->Perm = INTEGER(tmp);
-  ans->ColCount = INTEGER(GET_SLOT(x, install("colcount")));
-  ans->z = ans->x = (void *) NULL;
-  SEXP Matrix_xSym = install("x");
-  tmp = GET_SLOT(x, Matrix_xSym);
-  ans->x = REAL(tmp);
-  if (ans->is_super) {	/* supernodal factorization */
-    ans->xsize = LENGTH(tmp);
-    ans->maxcsize = type[4]; ans->maxesize = type[5];
-    ans->i = (int*)NULL;
-    tmp = GET_SLOT(x, install("super"));
-    ans->nsuper = LENGTH(tmp) - 1; ans->super = INTEGER(tmp);
-    tmp = GET_SLOT(x, install("pi"));
-    ans->pi = INTEGER(tmp);
-    tmp = GET_SLOT(x, install("px"));
-    ans->px = INTEGER(tmp);
-    tmp = GET_SLOT(x, install("s"));
-    ans->ssize = LENGTH(tmp); ans->s = INTEGER(tmp);
-  } else {
-    Rf_error("Unexpected");
-  }
-  return ans;
-}
-
 SEXP tmb_destructive_CHM_update(SEXP L, SEXP H, SEXP mult)
 {
     CHM_FR f = AS_CHM_FR(L);


### PR DESCRIPTION
The names and implementation details of factorization classes in **Matrix** may change as we generalize to support complex matrices.  **TMB** should use our API as much as possible to remain forward compatible, notably by _not_ redefining `AS_CHM_FR` in `src/solve_subset.c`.

If I understand correctly, the reason for redefining it in the first place was to avoid the overhead of an unconditional call to `cholmod_check_factor` in the underlying registered routine (named `sexp_as_cholmod_factor`, but originally `as_cholmod_factor`).

**Matrix** 1.7-1 will remove the call to `cholmod_check_factor` in `sexp_as_cholmod_factor` and let the caller of the latter decide whether to check.  Accordingly, it will also register and provide a stub for `cholmod_check_factor`.

My hope is that this PR can be merged either before or soon after **Matrix** 1.7-1 is released (date undecided but likely not earlier than June).  For testing:

```
svn checkout svn://svn.r-forge.r-project.org/svnroot/matrix/branches/Matrix-1-7-branch
cd Matrix-1-7-branch
svn diff -c 4751 src/cholmod-common.c
R CMD build .
R CMD INSTALL Matrix_1.7-1.tar.gz
```