### PR TITLE
Fix ISNAN macro in bessel.hpp for GCC C++17 compliance

### DIFF
--- a/TMB/inst/include/tiny_ad/bessel/bessel.hpp
+++ b/TMB/inst/include/tiny_ad/bessel/bessel.hpp
@@ -57,7 +57,7 @@ template<class T> int isnan(T x) { return std::isnan(asDouble(x)); }
 #define ML_NEGINF	R_NegInf
 #define ML_NAN		R_NaN
 #define M_SQRT_2dPI	0.797884560802865355879892119869	/* sqrt(2/pi) */
-#define ISNAN(x) (isnan(x)!=0)
+#define ISNAN(x) (std::isnan(asDouble(x))!=0)
 
 /* I got crashes with Eigen if not setting this: */
 #define MATHLIB_STANDALONE 1


### PR DESCRIPTION
The `ISNAN` macro expands to bare `isnan()` which GCC rejects in C++17 mode (`'isnan' was not declared in this scope`). Changed to `std::isnan(asDouble(x))` to match the existing `R_finite` pattern at line 32. Reproduces on Ubuntu with GCC + R >= 4.5; macOS clang is unaffected.