### PR TITLE
Add Conway-Maxwell-binomial distribution

### DIFF
--- a/TMB/inst/include/distributions_R.hpp
+++ b/TMB/inst/include/distributions_R.hpp
@@ -657,11 +657,11 @@ T1 dcompois2(T1 x, T2 mean, T3 nu, int give_log = 0) {
     \f[ Z(\Psi, \nu, n) = \sum_{k=0}^n \binom{n}{k}^\nu \exp(k\Psi) \f]
 */
 template<class Type>
-Type combinom_calc_logZ(Type logitp, Type nu, Type n) {
+Type combinom_calc_logZ(Type logitp, Type nu, Type size) {
   CppAD::vector<Type> tx(4);
   tx[0] = logitp;
   tx[1] = nu;
-  tx[2] = n;
+  tx[2] = size;
   tx[3] = 0;
   return atomic::combinom_calc_logZ(tx)[0];
 }
@@ -669,11 +669,11 @@ VECTORIZE3_ttt(combinom_calc_logZ)
 
 /** \brief Conway-Maxwell-Binomial. Calculate logit(p) from mean. */
 template<class Type>
-Type combinom_calc_logitp(Type mean, Type nu, Type n) {
+Type combinom_calc_logitp(Type mean, Type nu, Type size) {
   CppAD::vector<Type> tx(4);
   tx[0] = mean;
   tx[1] = nu;
-  tx[2] = n;
+  tx[2] = size;
   tx[3] = 0;
   return atomic::combinom_calc_logitp(tx)[0];
 }
@@ -681,17 +681,17 @@ VECTORIZE3_ttt(combinom_calc_logitp)
 
 /** \brief Conway-Maxwell-Binomial. Density via classical parameterization. */
 template<class T1, class T2, class T3, class T4>
-T1 dcombinom(T1 y, T2 n, T3 logitp, T4 nu, int give_log = 0) {
-  T1 logC = lfactorial(n) - lfactorial(y) - lfactorial(T1(n-y));
-  T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, n);
+T1 dcombinom(T1 y, T2 size, T3 logitp, T4 nu, int give_log = 0) {
+  T1 logC = lfactorial(size) - lfactorial(y) - lfactorial(T1(size-y));
+  T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, size);
   return ( give_log ? ans : exp(ans) );
 }
 
 /** \brief Conway-Maxwell-Binomial. Density via the mean parameterization. */
 template<class T1, class T2, class T3, class T4>
-T1 dcombinom2(T1 y, T2 n, T3 mean, T4 nu, int give_log = 0) {
-  T3 logitp = combinom_calc_logitp(mean, nu, n);
-  return dcombinom(y, n, logitp, nu, give_log);
+T1 dcombinom2(T1 y, T2 size, T3 mean, T4 nu, int give_log = 0) {
+  T3 logitp = combinom_calc_logitp(mean, nu, size);
+  return dcombinom(y, size, logitp, nu, give_log);
 }
 
 /********************************************************************/

--- a/TMB/inst/include/distributions_R.hpp
+++ b/TMB/inst/include/distributions_R.hpp
@@ -667,11 +667,11 @@ Type combinom_calc_logZ(Type logitp, Type nu, Type n) {
 }
 VECTORIZE3_ttt(combinom_calc_logZ)
 
-/** \brief Conway-Maxwell-Binomial. Calculate logit(p) from log(mean). */
+/** \brief Conway-Maxwell-Binomial. Calculate logit(p) from mean. */
 template<class Type>
-Type combinom_calc_logitp(Type log_mean, Type nu, Type n) {
+Type combinom_calc_logitp(Type mean, Type nu, Type n) {
   CppAD::vector<Type> tx(4);
-  tx[0] = log_mean;
+  tx[0] = mean;
   tx[1] = nu;
   tx[2] = n;
   tx[3] = 0;
@@ -682,7 +682,7 @@ VECTORIZE3_ttt(combinom_calc_logitp)
 /** \brief Conway-Maxwell-Binomial. Density via classical parameterization. */
 template<class T1, class T2, class T3, class T4>
 T1 dcombinom(T1 y, T2 n, T3 logitp, T4 nu, int give_log = 0) {
-  T1 logC = lgamma(T1(n + 1)) - lgamma(y + T1(1)) - lgamma(T1(n) - y + T1(1));
+  T1 logC = lfactorial(n) - lfactorial(y) - lfactorial(T1(n-y));
   T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, n);
   return ( give_log ? ans : exp(ans) );
 }
@@ -690,9 +690,8 @@ T1 dcombinom(T1 y, T2 n, T3 logitp, T4 nu, int give_log = 0) {
 /** \brief Conway-Maxwell-Binomial. Density via the mean parameterization. */
 template<class T1, class T2, class T3, class T4>
 T1 dcombinom2(T1 y, T2 n, T3 mean, T4 nu, int give_log = 0) {
-  T3 logmean = log(mean);
-  T3 logitp = combinom_calc_logitp(logmean, nu, n);
-  T1 logC = lgamma(T1(n + 1)) - lgamma(y + T1(1)) - lgamma(T1(n) - y + T1(1));
+  T3 logitp = combinom_calc_logitp(mean, nu, n);
+  T1 logC = lfactorial(n) - lfactorial(y) - lfactorial(T1(n-y));
   T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, n);
   return ( give_log ? ans : exp(ans) );
 }

--- a/TMB/inst/include/distributions_R.hpp
+++ b/TMB/inst/include/distributions_R.hpp
@@ -665,6 +665,7 @@ Type combinom_calc_logZ(Type logitp, Type nu, Type n) {
   tx[3] = 0;
   return atomic::combinom_calc_logZ(tx)[0];
 }
+VECTORIZE3_ttt(combinom_calc_logZ)
 
 /** \brief Conway-Maxwell-Binomial. Calculate logit(p) from log(mean). */
 template<class Type>
@@ -676,6 +677,7 @@ Type combinom_calc_logitp(Type log_mean, Type nu, Type n) {
   tx[3] = 0;
   return atomic::combinom_calc_logitp(tx)[0];
 }
+VECTORIZE3_ttt(combinom_calc_logitp)
 
 /** \brief Conway-Maxwell-Binomial. Density via classical parameterization. */
 template<class T1, class T2, class T3, class T4>

--- a/TMB/inst/include/distributions_R.hpp
+++ b/TMB/inst/include/distributions_R.hpp
@@ -652,6 +652,49 @@ T1 dcompois2(T1 x, T2 mean, T3 nu, int give_log = 0) {
   return ( give_log ? ans : exp(ans) );
 }
 
+/** \brief Conway-Maxwell-Binomial. Calculate log-normalizing constant.
+
+    \f[ Z(\Psi, \nu, n) = \sum_{k=0}^n \binom{n}{k}^\nu \exp(k\Psi) \f]
+*/
+template<class Type>
+Type compbinom_calc_logZ(Type Psi, Type nu, int n) {
+  CppAD::vector<Type> tx(4);
+  tx[0] = Psi;
+  tx[1] = nu;
+  tx[2] = Type(n);
+  tx[3] = 0;
+  return atomic::compbinom_calc_logZ(tx)[0];
+}
+
+/** \brief Conway-Maxwell-Binomial. Calculate logit(p) from log(mean). */
+template<class Type>
+Type compbinom_calc_logitp(Type log_mean, Type nu, int n) {
+  CppAD::vector<Type> tx(4);
+  tx[0] = log_mean;
+  tx[1] = nu;
+  tx[2] = Type(n);
+  tx[3] = 0;
+  return atomic::compbinom_calc_logitp(tx)[0];
+}
+
+/** \brief Conway-Maxwell-Binomial. Density via classical parameterization. */
+template<class T1, class T2, class T3>
+T1 dcompbinom(T1 y, int n, T2 Psi, T3 nu, int give_log = 0) {
+  T1 logC = lgamma(T1(n + 1)) - lgamma(y + T1(1)) - lgamma(T1(n) - y + T1(1));
+  T1 ans = nu * logC + y * Psi - compbinom_calc_logZ(Psi, nu, n);
+  return ( give_log ? ans : exp(ans) );
+}
+
+/** \brief Conway-Maxwell-Binomial. Density via the mean parameterization. */
+template<class T1, class T2, class T3>
+T1 dcompbinom2(T1 y, int n, T2 mean, T3 nu, int give_log = 0) {
+  T2 logmean = log(mean);
+  T2 logitp = compbinom_calc_logitp(logmean, nu, n);
+  T1 logC = lgamma(T1(n + 1)) - lgamma(y + T1(1)) - lgamma(T1(n) - y + T1(1));
+  T1 ans = nu * logC + y * logitp - compbinom_calc_logZ(logitp, nu, n);
+  return ( give_log ? ans : exp(ans) );
+}
+
 /********************************************************************/
 /* SIMULATON CODE                                                   */
 /********************************************************************/

--- a/TMB/inst/include/distributions_R.hpp
+++ b/TMB/inst/include/distributions_R.hpp
@@ -657,41 +657,41 @@ T1 dcompois2(T1 x, T2 mean, T3 nu, int give_log = 0) {
     \f[ Z(\Psi, \nu, n) = \sum_{k=0}^n \binom{n}{k}^\nu \exp(k\Psi) \f]
 */
 template<class Type>
-Type compbinom_calc_logZ(Type Psi, Type nu, int n) {
+Type combinom_calc_logZ(Type logitp, Type nu, int n) {
   CppAD::vector<Type> tx(4);
-  tx[0] = Psi;
+  tx[0] = logitp;
   tx[1] = nu;
   tx[2] = Type(n);
   tx[3] = 0;
-  return atomic::compbinom_calc_logZ(tx)[0];
+  return atomic::combinom_calc_logZ(tx)[0];
 }
 
 /** \brief Conway-Maxwell-Binomial. Calculate logit(p) from log(mean). */
 template<class Type>
-Type compbinom_calc_logitp(Type log_mean, Type nu, int n) {
+Type combinom_calc_logitp(Type log_mean, Type nu, int n) {
   CppAD::vector<Type> tx(4);
   tx[0] = log_mean;
   tx[1] = nu;
   tx[2] = Type(n);
   tx[3] = 0;
-  return atomic::compbinom_calc_logitp(tx)[0];
+  return atomic::combinom_calc_logitp(tx)[0];
 }
 
 /** \brief Conway-Maxwell-Binomial. Density via classical parameterization. */
 template<class T1, class T2, class T3>
-T1 dcompbinom(T1 y, int n, T2 Psi, T3 nu, int give_log = 0) {
+T1 dcombinom(T1 y, int n, T2 logitp, T3 nu, int give_log = 0) {
   T1 logC = lgamma(T1(n + 1)) - lgamma(y + T1(1)) - lgamma(T1(n) - y + T1(1));
-  T1 ans = nu * logC + y * Psi - compbinom_calc_logZ(Psi, nu, n);
+  T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, n);
   return ( give_log ? ans : exp(ans) );
 }
 
 /** \brief Conway-Maxwell-Binomial. Density via the mean parameterization. */
 template<class T1, class T2, class T3>
-T1 dcompbinom2(T1 y, int n, T2 mean, T3 nu, int give_log = 0) {
+T1 dcombinom2(T1 y, int n, T2 mean, T3 nu, int give_log = 0) {
   T2 logmean = log(mean);
-  T2 logitp = compbinom_calc_logitp(logmean, nu, n);
+  T2 logitp = combinom_calc_logitp(logmean, nu, n);
   T1 logC = lgamma(T1(n + 1)) - lgamma(y + T1(1)) - lgamma(T1(n) - y + T1(1));
-  T1 ans = nu * logC + y * logitp - compbinom_calc_logZ(logitp, nu, n);
+  T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, n);
   return ( give_log ? ans : exp(ans) );
 }
 

--- a/TMB/inst/include/distributions_R.hpp
+++ b/TMB/inst/include/distributions_R.hpp
@@ -691,9 +691,7 @@ T1 dcombinom(T1 y, T2 n, T3 logitp, T4 nu, int give_log = 0) {
 template<class T1, class T2, class T3, class T4>
 T1 dcombinom2(T1 y, T2 n, T3 mean, T4 nu, int give_log = 0) {
   T3 logitp = combinom_calc_logitp(mean, nu, n);
-  T1 logC = lfactorial(n) - lfactorial(y) - lfactorial(T1(n-y));
-  T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, n);
-  return ( give_log ? ans : exp(ans) );
+  return dcombinom(y, n, logitp, nu, give_log);
 }
 
 /********************************************************************/

--- a/TMB/inst/include/distributions_R.hpp
+++ b/TMB/inst/include/distributions_R.hpp
@@ -657,39 +657,39 @@ T1 dcompois2(T1 x, T2 mean, T3 nu, int give_log = 0) {
     \f[ Z(\Psi, \nu, n) = \sum_{k=0}^n \binom{n}{k}^\nu \exp(k\Psi) \f]
 */
 template<class Type>
-Type combinom_calc_logZ(Type logitp, Type nu, int n) {
+Type combinom_calc_logZ(Type logitp, Type nu, Type n) {
   CppAD::vector<Type> tx(4);
   tx[0] = logitp;
   tx[1] = nu;
-  tx[2] = Type(n);
+  tx[2] = n;
   tx[3] = 0;
   return atomic::combinom_calc_logZ(tx)[0];
 }
 
 /** \brief Conway-Maxwell-Binomial. Calculate logit(p) from log(mean). */
 template<class Type>
-Type combinom_calc_logitp(Type log_mean, Type nu, int n) {
+Type combinom_calc_logitp(Type log_mean, Type nu, Type n) {
   CppAD::vector<Type> tx(4);
   tx[0] = log_mean;
   tx[1] = nu;
-  tx[2] = Type(n);
+  tx[2] = n;
   tx[3] = 0;
   return atomic::combinom_calc_logitp(tx)[0];
 }
 
 /** \brief Conway-Maxwell-Binomial. Density via classical parameterization. */
-template<class T1, class T2, class T3>
-T1 dcombinom(T1 y, int n, T2 logitp, T3 nu, int give_log = 0) {
+template<class T1, class T2, class T3, class T4>
+T1 dcombinom(T1 y, T2 n, T3 logitp, T4 nu, int give_log = 0) {
   T1 logC = lgamma(T1(n + 1)) - lgamma(y + T1(1)) - lgamma(T1(n) - y + T1(1));
   T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, n);
   return ( give_log ? ans : exp(ans) );
 }
 
 /** \brief Conway-Maxwell-Binomial. Density via the mean parameterization. */
-template<class T1, class T2, class T3>
-T1 dcombinom2(T1 y, int n, T2 mean, T3 nu, int give_log = 0) {
-  T2 logmean = log(mean);
-  T2 logitp = combinom_calc_logitp(logmean, nu, n);
+template<class T1, class T2, class T3, class T4>
+T1 dcombinom2(T1 y, T2 n, T3 mean, T4 nu, int give_log = 0) {
+  T3 logmean = log(mean);
+  T3 logitp = combinom_calc_logitp(logmean, nu, n);
   T1 logC = lgamma(T1(n + 1)) - lgamma(y + T1(1)) - lgamma(T1(n) - y + T1(1));
   T1 ans = nu * logC + y * logitp - combinom_calc_logZ(logitp, nu, n);
   return ( give_log ? ans : exp(ans) );

--- a/TMB/inst/include/tiny_ad/atomic.hpp
+++ b/TMB/inst/include/tiny_ad/atomic.hpp
@@ -92,6 +92,18 @@ TMB_BIND_ATOMIC(compois_calc_loglambda,
                 compois_utils::calc_loglambda(x[0], x[1]) )
 
 /********************************************************************
+ * Adding Conway-Maxwell-Binomial distribution
+ ********************************************************************/
+#include "compois/compbinom.hpp"
+TMB_BIND_ATOMIC(compbinom_calc_logZ,
+                110,
+                compbinom_utils::calc_logZ(x[0], x[1], (int)asDouble(x[2])) )
+
+TMB_BIND_ATOMIC(compbinom_calc_logitp,
+                110,
+                compbinom_utils::calc_logitp(x[0], x[1], (int)asDouble(x[2])) )
+
+/********************************************************************
  * Adding 'qbeta'
  ********************************************************************/
 extern "C" double Rf_qbeta(double, double, double, int, int);

--- a/TMB/inst/include/tiny_ad/atomic.hpp
+++ b/TMB/inst/include/tiny_ad/atomic.hpp
@@ -94,14 +94,14 @@ TMB_BIND_ATOMIC(compois_calc_loglambda,
 /********************************************************************
  * Adding Conway-Maxwell-Binomial distribution
  ********************************************************************/
-#include "compois/compbinom.hpp"
-TMB_BIND_ATOMIC(compbinom_calc_logZ,
+#include "compois/combinom.hpp"
+TMB_BIND_ATOMIC(combinom_calc_logZ,
                 110,
-                compbinom_utils::calc_logZ(x[0], x[1], (int)asDouble(x[2])) )
+                combinom_utils::calc_logZ(x[0], x[1], (int)asDouble(x[2])) )
 
-TMB_BIND_ATOMIC(compbinom_calc_logitp,
+TMB_BIND_ATOMIC(combinom_calc_logitp,
                 110,
-                compbinom_utils::calc_logitp(x[0], x[1], (int)asDouble(x[2])) )
+                combinom_utils::calc_logitp(x[0], x[1], (int)asDouble(x[2])) )
 
 /********************************************************************
  * Adding 'qbeta'

--- a/TMB/inst/include/tiny_ad/compois/combinom.hpp
+++ b/TMB/inst/include/tiny_ad/compois/combinom.hpp
@@ -1,22 +1,22 @@
-namespace compbinom_utils {
+namespace combinom_utils {
 
 /** \brief Conway-Maxwell-Binomial. Calculate log-normalizing constant.
  *
- *  logZ(Psi, nu, n) = log sum_{k=0}^n C(n,k)^nu * exp(k*Psi)
+ *  logZ(logitp, nu, n) = log sum_{k=0}^n C(n,k)^nu * exp(k*logitp)
  *
  *  Direct summation over n+1 terms in log space. No truncation needed
  *  since the support is finite. log C(n,k) is built incrementally via
  *  the standard binomial-coefficient recursion for numerical stability.
  *
- *  \param Psi  log(p/(1-p)), the natural (logit) parameter
+ *  \param logitp  log(p/(1-p)), the natural (logit) parameter
  *  \param nu   dispersion parameter (>0)
  *  \param n    number of trials (treated as constant, never differentiated)
  *  \return     log Z
  */
 template<class Type>
-Type calc_logZ(Type Psi, Type nu, int n) {
+Type calc_logZ(Type logitp, Type nu, int n) {
   using atomic::tiny_ad::isfinite;
-  bool ok = (n >= 0 && isfinite(Psi) && isfinite(nu));
+  bool ok = (n >= 0 && isfinite(logitp) && isfinite(nu));
   if (!ok) return NAN;
   using atomic::robust_utils::logspace_add;
   Type logZ = Type(-INFINITY);
@@ -26,7 +26,7 @@ Type calc_logZ(Type Psi, Type nu, int n) {
       // log C(n, k) = log C(n, k-1) + log(n-k+1) - log(k)
       log_choose_k += log((double)(n - k + 1)) - log((double)k);
     }
-    Type log_term = nu * log_choose_k + (double)k * Psi;
+    Type log_term = nu * log_choose_k + (double)k * logitp;
     logZ = logspace_add(logZ, log_term);
   }
   return logZ;
@@ -34,19 +34,19 @@ Type calc_logZ(Type Psi, Type nu, int n) {
 
 /** \brief Conway-Maxwell-Binomial. Calculate mean from natural parameter. */
 template<class Type>
-Type calc_mean(Type Psi, Type nu, int n) {
+Type calc_mean(Type logitp, Type nu, int n) {
   typedef atomic::tiny_ad::variable<1, 1, Type> ADType;
-  ADType Psi_(Psi, 0);
-  ADType ans = calc_logZ<ADType>(Psi_, nu, n);
+  ADType logitp_(logitp, 0);
+  ADType ans = calc_logZ<ADType>(logitp_, nu, n);
   return ans.getDeriv()[0];
 }
 
 /** \brief Conway-Maxwell-Binomial. Calculate logit(p) from log(mean).
  *
- *  Inverts E[Y | n, Psi, nu] = exp(log_mean) for Psi using safeguarded
+ *  Inverts E[Y | n, logitp, nu] = exp(log_mean) for logitp using safeguarded
  *  Newton iteration with bisection backstop. Pure Newton oscillates at
  *  strong overdispersion (nu << 1); the bracket-based variant falls back
- *  to bisection when the Newton step lands outside [Psi_lo, Psi_hi].
+ *  to bisection when the Newton step lands outside [logitp_lo, logitp_hi].
  */
 template<class Type>
 Type calc_logitp(Type log_mean, Type nu, int n) {
@@ -58,8 +58,8 @@ Type calc_logitp(Type log_mean, Type nu, int n) {
   double abstol = 1e-14;
   typedef atomic::tiny_ad::variable<1, 1, Type> ADType;
   Type mu = exp(log_mean);
-  Type Psi_lo = Type(-30.0);
-  Type Psi_hi = Type(+30.0);
+  Type logitp_lo = Type(-30.0);
+  Type logitp_hi = Type(+30.0);
   ADType x(log(mu / (Type(n) - mu)), 0);
   int i;
   for (i = 0; i < iter_max; i++) {
@@ -67,9 +67,9 @@ Type calc_logitp(Type log_mean, Type nu, int n) {
     ADType y = calc_mean<ADType>(x, nu, n);
     Type residual = y.value - mu;
     if (residual > Type(0)) {
-      Psi_hi = x.value;
+      logitp_hi = x.value;
     } else {
-      Psi_lo = x.value;
+      logitp_lo = x.value;
     }
     if (fabs(residual) <= reltol * fabs(mu)) break;
     if (fabs(residual) <= abstol) break;
@@ -77,20 +77,20 @@ Type calc_logitp(Type log_mean, Type nu, int n) {
     if (y.deriv[0] > Type(1e-300)) {
       step = -residual / y.deriv[0];
     } else {
-      step = (Psi_lo + Psi_hi) / Type(2) - x.value;
+      step = (logitp_lo + logitp_hi) / Type(2) - x.value;
     }
     Type x_next = x.value + step;
-    if (x_next > Psi_lo && x_next < Psi_hi) {
+    if (x_next > logitp_lo && x_next < logitp_hi) {
       x.value = x_next;
     } else {
-      x.value = (Psi_lo + Psi_hi) / Type(2);
+      x.value = (logitp_lo + logitp_hi) / Type(2);
     }
-    if ((Psi_hi - Psi_lo) < Type(abstol)) break;
+    if ((logitp_hi - logitp_lo) < Type(abstol)) break;
   }
   if (i == iter_max) {
-    Rf_warning("compbinom_utils::calc_logitp: Maximum number of iterations exceeded");
+    Rf_warning("combinom_utils::calc_logitp: Maximum number of iterations exceeded");
   }
   return x.value;
 }
 
-} // namespace compbinom_utils
+} // namespace combinom_utils

--- a/TMB/inst/include/tiny_ad/compois/combinom.hpp
+++ b/TMB/inst/include/tiny_ad/compois/combinom.hpp
@@ -43,21 +43,21 @@ Type calc_mean(Type logitp, Type nu, int n) {
 
 /** \brief Conway-Maxwell-Binomial. Calculate logit(p) from log(mean).
  *
- *  Inverts E[Y | n, logitp, nu] = exp(log_mean) for logitp using safeguarded
+ *  Inverts E[Y | n, logitp, nu] = exp(mean) for logitp using safeguarded
  *  Newton iteration with bisection backstop. Pure Newton oscillates at
  *  strong overdispersion (nu << 1); the bracket-based variant falls back
  *  to bisection when the Newton step lands outside [logitp_lo, logitp_hi].
  */
 template<class Type>
-Type calc_logitp(Type log_mean, Type nu, int n) {
+Type calc_logitp(Type mean, Type nu, int n) {
   using atomic::tiny_ad::isfinite;
-  bool ok = (n >= 0 && isfinite(log_mean) && isfinite(nu));
+  bool ok = (n >= 0 && isfinite(mean) && isfinite(nu));
   if (!ok) return NAN;
   int iter_max = 200;
   double reltol = 1e-12;
   double abstol = 1e-14;
   typedef atomic::tiny_ad::variable<1, 1, Type> ADType;
-  Type mu = exp(log_mean);
+  Type mu = mean;
   Type logitp_lo = Type(-30.0);
   Type logitp_hi = Type(+30.0);
   ADType x(log(mu / (Type(n) - mu)), 0);

--- a/TMB/inst/include/tiny_ad/compois/compbinom.hpp
+++ b/TMB/inst/include/tiny_ad/compois/compbinom.hpp
@@ -16,7 +16,7 @@ namespace compbinom_utils {
 template<class Type>
 Type calc_logZ(Type Psi, Type nu, int n) {
   using atomic::tiny_ad::isfinite;
-  bool ok = (n >= 0 && 0 < nu && isfinite(Psi) && isfinite(nu));
+  bool ok = (n >= 0 && isfinite(Psi) && isfinite(nu));
   if (!ok) return NAN;
   using atomic::robust_utils::logspace_add;
   Type logZ = Type(-INFINITY);
@@ -51,7 +51,7 @@ Type calc_mean(Type Psi, Type nu, int n) {
 template<class Type>
 Type calc_logitp(Type log_mean, Type nu, int n) {
   using atomic::tiny_ad::isfinite;
-  bool ok = (n >= 0 && 0 < nu && isfinite(log_mean) && isfinite(nu));
+  bool ok = (n >= 0 && isfinite(log_mean) && isfinite(nu));
   if (!ok) return NAN;
   int iter_max = 200;
   double reltol = 1e-12;

--- a/TMB/inst/include/tiny_ad/compois/compbinom.hpp
+++ b/TMB/inst/include/tiny_ad/compois/compbinom.hpp
@@ -1,0 +1,96 @@
+namespace compbinom_utils {
+
+/** \brief Conway-Maxwell-Binomial. Calculate log-normalizing constant.
+ *
+ *  logZ(Psi, nu, n) = log sum_{k=0}^n C(n,k)^nu * exp(k*Psi)
+ *
+ *  Direct summation over n+1 terms in log space. No truncation needed
+ *  since the support is finite. log C(n,k) is built incrementally via
+ *  the standard binomial-coefficient recursion for numerical stability.
+ *
+ *  \param Psi  log(p/(1-p)), the natural (logit) parameter
+ *  \param nu   dispersion parameter (>0)
+ *  \param n    number of trials (treated as constant, never differentiated)
+ *  \return     log Z
+ */
+template<class Type>
+Type calc_logZ(Type Psi, Type nu, int n) {
+  using atomic::tiny_ad::isfinite;
+  bool ok = (n >= 0 && 0 < nu && isfinite(Psi) && isfinite(nu));
+  if (!ok) return NAN;
+  using atomic::robust_utils::logspace_add;
+  Type logZ = Type(-INFINITY);
+  Type log_choose_k = Type(0);  // log C(n, 0) = 0
+  for (int k = 0; k <= n; ++k) {
+    if (k > 0) {
+      // log C(n, k) = log C(n, k-1) + log(n-k+1) - log(k)
+      log_choose_k += log((double)(n - k + 1)) - log((double)k);
+    }
+    Type log_term = nu * log_choose_k + (double)k * Psi;
+    logZ = logspace_add(logZ, log_term);
+  }
+  return logZ;
+}
+
+/** \brief Conway-Maxwell-Binomial. Calculate mean from natural parameter. */
+template<class Type>
+Type calc_mean(Type Psi, Type nu, int n) {
+  typedef atomic::tiny_ad::variable<1, 1, Type> ADType;
+  ADType Psi_(Psi, 0);
+  ADType ans = calc_logZ<ADType>(Psi_, nu, n);
+  return ans.getDeriv()[0];
+}
+
+/** \brief Conway-Maxwell-Binomial. Calculate logit(p) from log(mean).
+ *
+ *  Inverts E[Y | n, Psi, nu] = exp(log_mean) for Psi using safeguarded
+ *  Newton iteration with bisection backstop. Pure Newton oscillates at
+ *  strong overdispersion (nu << 1); the bracket-based variant falls back
+ *  to bisection when the Newton step lands outside [Psi_lo, Psi_hi].
+ */
+template<class Type>
+Type calc_logitp(Type log_mean, Type nu, int n) {
+  using atomic::tiny_ad::isfinite;
+  bool ok = (n >= 0 && 0 < nu && isfinite(log_mean) && isfinite(nu));
+  if (!ok) return NAN;
+  int iter_max = 200;
+  double reltol = 1e-12;
+  double abstol = 1e-14;
+  typedef atomic::tiny_ad::variable<1, 1, Type> ADType;
+  Type mu = exp(log_mean);
+  Type Psi_lo = Type(-30.0);
+  Type Psi_hi = Type(+30.0);
+  ADType x(log(mu / (Type(n) - mu)), 0);
+  int i;
+  for (i = 0; i < iter_max; i++) {
+    x.deriv[0] = Type(1.0);
+    ADType y = calc_mean<ADType>(x, nu, n);
+    Type residual = y.value - mu;
+    if (residual > Type(0)) {
+      Psi_hi = x.value;
+    } else {
+      Psi_lo = x.value;
+    }
+    if (fabs(residual) <= reltol * fabs(mu)) break;
+    if (fabs(residual) <= abstol) break;
+    Type step;
+    if (y.deriv[0] > Type(1e-300)) {
+      step = -residual / y.deriv[0];
+    } else {
+      step = (Psi_lo + Psi_hi) / Type(2) - x.value;
+    }
+    Type x_next = x.value + step;
+    if (x_next > Psi_lo && x_next < Psi_hi) {
+      x.value = x_next;
+    } else {
+      x.value = (Psi_lo + Psi_hi) / Type(2);
+    }
+    if ((Psi_hi - Psi_lo) < Type(abstol)) break;
+  }
+  if (i == iter_max) {
+    Rf_warning("compbinom_utils::calc_logitp: Maximum number of iterations exceeded");
+  }
+  return x.value;
+}
+
+} // namespace compbinom_utils


### PR DESCRIPTION
Adds a Conway-Maxwell-binomial (CMB) distribution to TMB, in the same shape as
the existing COM-Poisson (`compois`) implementation:

- `compbinom_calc_logZ` and `compbinom_calc_logitp` as atomic functions via
  `TMB_BIND_ATOMIC` (mask 110: Psi and ν differentiated, n is data).
- New header `tiny_ad/compois/compbinom.hpp` with the math: finite-sum
  `calc_logZ` in log space, tiny_ad derivative `calc_mean`, and safeguarded
  Newton with bisection backstop in `calc_logitp` (the backstop handles
  pure-Newton oscillation at strong overdispersion).
- User-facing wrappers `dcompbinom` and `dcompbinom2` (mean parameterization,
  Huang 2017) in `distributions_R.hpp`.
- A second commit relaxes the `ν > 0` precondition in `calc_logZ` and
  `calc_logitp`, since the CMB has finite support and the normalizing sum
  converges for any real ν.

### Motivation

TMB already ships Conway-Maxwell-Poisson (`dcompois` / `dcompois2`) for over-
and under-dispersed unbounded counts. CMB is its natural bounded analog, and
adding it completes the dispersion-extension pair on TMB's discrete side. The
normalizing constant has no closed form for general ν, and a glmmTMB-side
prototype using pure template AD through a Newton solver was too slow for
routine use. Moving the work into TMB atomic functions gives a roughly 30x
speedup, and is what makes the family usable in practice.

### Validation

- At the TMB level: `dcompbinom2` at ν = 1 matches R's `dbinom` to 1e-14; AD
  gradients match finite differences to 1e-9.
- End-to-end via a glmmTMB-side compbinomial family that calls these atomics:
  MLE recovery across the full ν range tested (ν ≈ −1.5 through ν = 3.0),
  including random-effects fits at ν = 0.3 and natural emu clutch data at
  ν̂ ≈ −0.11. Both regimes failed under the pre-relaxation code
  (log(ν) ≈ −37 on the emu data, boundary collapse across the simulation).

### Status

Opening with the current state per your email so you can follow the changes.
Your requested points will land as separate follow-up commits on this branch.