### PR TITLE
fix PROTECT/UNPROTECT comments that broke macros

### DIFF
--- a/TMB/inst/include/tmb_core.hpp
+++ b/TMB/inst/include/tmb_core.hpp
@@ -6,14 +6,14 @@
 */
 
 /*
-  Call to external C++ code can potentially result in exeptions that
+  Call to external C++ code can potentially result in exceptions that
   will crash R. However, we do not want R to crash on failed memory
   allocations. Therefore:
 
   * All interface functions (those called with .Call from R) must have
     TMB_TRY wrapped around CppAD/Eigen code that allocates memory.
 
-  * Special attention must be payed to parallel code, as each thread
+  * Special attention must be paid to parallel code, as each thread
     is responsible for catching its own exceptions.
 */
 

--- a/TMB/inst/include/tmb_core.hpp
+++ b/TMB/inst/include/tmb_core.hpp
@@ -210,10 +210,14 @@ this
 
 /** \brief Get parameter matrix from R and declare it as matrix<Type>
     \ingroup macros */
-#define PARAMETER_MATRIX(name)                                          \
-tmbutils::matrix<Type> name(TMB_OBJECTIVE_PTR -> fillShape(             \
-asMatrix<Type> ( TMB_OBJECTIVE_PTR -> getShape( #name, &Rf_isMatrix) ), \
-#name) );
+#define PARAMETER_MATRIX(name)                                  \
+tmbutils::matrix<Type> name(TMB_OBJECTIVE_PTR -> fillShape(     \
+// PROTECT/UNPROTECT not necessary;
+// it's included to suppress a false-positive error from CRAN's rchk tests
+asMatrix<Type> ( PROTECT(                                       \
+TMB_OBJECTIVE_PTR -> getShape( #name, &Rf_isMatrix) ) ),        \
+#name) );                                                       \
+UNPROTECT(1);
 
 /** \brief Get parameter vector from R and declare it as vector<Type> 
     \ingroup macros*/

--- a/TMB/inst/include/tmb_core.hpp
+++ b/TMB/inst/include/tmb_core.hpp
@@ -212,8 +212,8 @@ this
     \ingroup macros */
 #define PARAMETER_MATRIX(name)                                  \
 tmbutils::matrix<Type> name(TMB_OBJECTIVE_PTR -> fillShape(     \
-// PROTECT/UNPROTECT not necessary;
-// it's included to suppress a false-positive error from CRAN's rchk tests
+/* PROTECT/UNPROTECT not necessary; included to suppress a  */ \
+/* false-positive error from CRAN's rchk tests               */ \
 asMatrix<Type> ( PROTECT(                                       \
 TMB_OBJECTIVE_PTR -> getShape( #name, &Rf_isMatrix) ) ),        \
 #name) );                                                       \
@@ -543,9 +543,9 @@ if (!Rf_isNull(getListElement(TMB_OBJECTIVE_PTR -> parameters,#name))){ \
 #define DATA_VECTOR_INDICATOR(name, obs)                                \
 data_indicator<tmbutils::vector<Type> > name(obs, true);                \
 if (!Rf_isNull(getListElement(TMB_OBJECTIVE_PTR -> parameters,#name))){ \
-  // PROTECT/UNPROTECT wrapper is not really necessary;
-  //  it's included to suppress a false-positive error from CRAN's rchk tests
-  // getShape() doesn't really allocate memory
+  /* PROTECT/UNPROTECT wrapper is not really necessary; included to  */ \
+  /* suppress a false-positive error from CRAN's rchk tests --       */ \
+  /* getShape() doesn't really allocate memory                       */ \
   SEXP _TMB_shape_sexp_;                                                \
   PROTECT(_TMB_shape_sexp_ =                                            \
             TMB_OBJECTIVE_PTR -> getShape(#name, &Rf_isReal));          \

--- a/TMB/inst/include/tmb_core.hpp
+++ b/TMB/inst/include/tmb_core.hpp
@@ -522,12 +522,13 @@ struct data_indicator : VT{
 #define DATA_ARRAY_INDICATOR(name, obs)                                 \
 data_indicator<tmbutils::array<Type> > name(obs, true);                 \
 if (!Rf_isNull(getListElement(TMB_OBJECTIVE_PTR -> parameters,#name))){ \
-  name.fill( TMB_OBJECTIVE_PTR -> fillShape(asVector<Type>(             \
-             TMB_OBJECTIVE_PTR -> getShape(#name, &Rf_isReal   )),      \
-                                           #name),                      \
-             Rf_getAttrib(                                              \
-                TMB_OBJECTIVE_PTR -> getShape(#name, &Rf_isReal   ),    \
-                Rf_install("ord")) );                                   \
+  SEXP _TMB_shape_sexp_;                                                \
+  PROTECT(_TMB_shape_sexp_ =                                            \
+            TMB_OBJECTIVE_PTR -> getShape(#name, &Rf_isReal));          \
+  name.fill( TMB_OBJECTIVE_PTR -> fillShape(                            \
+               asVector<Type>(_TMB_shape_sexp_), #name),                \
+             Rf_getAttrib(_TMB_shape_sexp_, Rf_install("ord")) );       \
+  UNPROTECT(1);                                                         \
 }
 
 /** \brief Declare an indicator vector 'name' of same shape as 'obs'. By default, the indicator vector is filled with ones indicating that all observations are enabled.
@@ -538,12 +539,16 @@ if (!Rf_isNull(getListElement(TMB_OBJECTIVE_PTR -> parameters,#name))){ \
 #define DATA_VECTOR_INDICATOR(name, obs)                                \
 data_indicator<tmbutils::vector<Type> > name(obs, true);                \
 if (!Rf_isNull(getListElement(TMB_OBJECTIVE_PTR -> parameters,#name))){ \
-  name.fill( TMB_OBJECTIVE_PTR -> fillShape(asVector<Type>(             \
-             TMB_OBJECTIVE_PTR -> getShape(#name, &Rf_isReal   )),      \
-                                           #name),                      \
-             Rf_getAttrib(                                              \
-                TMB_OBJECTIVE_PTR -> getShape(#name, &Rf_isReal   ),    \
-                Rf_install("ord")) );                                   \
+  // PROTECT/UNPROTECT wrapper is not really necessary;
+  //  it's included to suppress a false-positive error from CRAN's rchk tests
+  // getShape() doesn't really allocate memory
+  SEXP _TMB_shape_sexp_;                                                \
+  PROTECT(_TMB_shape_sexp_ =                                            \
+            TMB_OBJECTIVE_PTR -> getShape(#name, &Rf_isReal));          \
+  name.fill( TMB_OBJECTIVE_PTR -> fillShape(                            \
+               asVector<Type>(_TMB_shape_sexp_), #name),                \
+             Rf_getAttrib(_TMB_shape_sexp_, Rf_install("ord")) );       \
+  UNPROTECT(1);                                                         \
 }
 
 // kasper: Not sure used anywhere


### PR DESCRIPTION
Fix BMB mistake (human-only, not LLM-assisted!) in formatting comments about PROTECT/UNPROTECT being unnecessary.