### PR TITLE
`calc_logitp`: verify root bracket and preserve implicit AD derivatives

### DIFF
--- a/TMB/inst/include/tiny_ad/compois/combinom.hpp
+++ b/TMB/inst/include/tiny_ad/compois/combinom.hpp
@@ -54,25 +54,75 @@ Type calc_logitp(Type mean, Type nu, int n) {
   bool ok = (n >= 0 && isfinite(mean) && isfinite(nu));
   if (!ok) return NAN;
   int iter_max = 200;
+  int expand_max = 200;
   double reltol = 1e-12;
   double abstol = 1e-14;
   typedef atomic::tiny_ad::variable<1, 1, Type> ADType;
   Type mu = mean;
-  Type logitp_lo = Type(-30.0);
-  Type logitp_hi = Type(+30.0);
-  ADType x(log(mu / (Type(n) - mu)), 0);
+  /* Scaled starting value. At nu = 1 the CMB is binomial and the root is
+     exactly logit(mu/n). For nu > 1 it scales roughly as nu * logit(mu/n);
+     for nu < 0 it compresses by roughly n. */
+  Type logit0 = log(mu / (Type(n) - mu));
+  Type x0;
+  if (nu >= Type(1)) {
+    x0 = nu * logit0;
+  } else if (nu > Type(0)) {
+    x0 = logit0;
+  } else {
+    x0 = logit0 / Type(n);
+  }
+  /* Establish the bracket by outward expansion and verify it before
+     iterating. E[Y | logitp] is strictly increasing with limits 0 and n,
+     so a root exists for every 0 < mu < n and the expansion terminates. */
+  Type logitp_lo = x0;
+  Type logitp_hi = x0;
+  Type h = fabs(x0);
+  if (h < Type(1)) h = Type(1);
+  Type m = calc_mean<Type>(x0, nu, n);
+  int e = 0;
+  bool bracketed = true;
+  if (m > mu) {
+    while (m > mu && e < expand_max) {
+      logitp_lo -= h;
+      h *= Type(2);
+      e++;
+      m = calc_mean<Type>(logitp_lo, nu, n);
+    }
+    bracketed = (m <= mu);
+  } else if (m < mu) {
+    while (m < mu && e < expand_max) {
+      logitp_hi += h;
+      h *= Type(2);
+      e++;
+      m = calc_mean<Type>(logitp_hi, nu, n);
+    }
+    bracketed = (m >= mu);
+  }
+  if (!bracketed) {
+    Rf_warning("combinom_utils::calc_logitp: failed to bracket the root");
+    return NAN;
+  }
+  ADType x(x0, 0);
   int i;
   for (i = 0; i < iter_max; i++) {
     x.deriv[0] = Type(1.0);
     ADType y = calc_mean<ADType>(x, nu, n);
     Type residual = y.value - mu;
+    /* Apply one Newton correction at convergence. Numerically negligible
+       there, but it propagates the implicit derivative of the root: if the
+       starting value is already the root (nu == 1), the raw iterate carries
+       d(x0)/d(nu) instead of -Cov(Y, lchoose(n,Y))/Var(Y). */
+    if (fabs(residual) <= reltol * fabs(mu) || fabs(residual) <= abstol) {
+      if (y.deriv[0] > Type(1e-300)) {
+        x.value = x.value - residual / y.deriv[0];
+      }
+      break;
+    }
     if (residual > Type(0)) {
       logitp_hi = x.value;
     } else {
       logitp_lo = x.value;
     }
-    if (fabs(residual) <= reltol * fabs(mu)) break;
-    if (fabs(residual) <= abstol) break;
     Type step;
     if (y.deriv[0] > Type(1e-300)) {
       step = -residual / y.deriv[0];
@@ -85,7 +135,6 @@ Type calc_logitp(Type mean, Type nu, int n) {
     } else {
       x.value = (logitp_lo + logitp_hi) / Type(2);
     }
-    if ((logitp_hi - logitp_lo) < Type(abstol)) break;
   }
   if (i == iter_max) {
     Rf_warning("combinom_utils::calc_logitp: Maximum number of iterations exceeded");


### PR DESCRIPTION
# `calc_logitp`: verify root bracket and preserve implicit AD derivatives

Two defects in `calc_logitp` (from #415, my code). The first appears under strong underdispersion near the response boundary; the second occurs when the initial value is already the exact root, notably at `nu = 1`.

## 1. Fixed bracket is assumed rather than verified

`calc_logitp` initializes `[-30, +30]` and never verifies that it brackets the root.

The root scales roughly as

```text
nu * logit(mean / n)
```

so it leaves this interval once

```text
nu * |logit(mean / n)| > 30.
```

The residual then never changes sign, one bracket endpoint remains pinned at `+/-30`, and the loop can exit through the interval-width test rather than residual convergence. Since `i` does not reach `iter_max`, no warning is emitted.

On a 120-cell grid

```text
n        in {20, 100, 500}
nu       in {-5, -1, 0.5, 1, 4, 8, 15, 30}
mean / n in {0.02, 0.1, 0.5, 0.9, 0.99}
```

27 cells return an incorrect mean, with worst absolute error in `mean / n` of 0.2585:

| n | nu | requested mean/n | returned logitp | true logitp | implied mean/n |
|---:|---:|-----------------:|----------------:|------------:|---------------:|
| 500 | 30 | 0.99 | 30.000 | 135.150 | 0.7315 |
| 100 | 30 | 0.99 | 30.000 | 127.607 | 0.7333 |
| 500 | 30 | 0.02 | -30.000 | -115.362 | 0.2685 |
| 100 | 30 | 0.90 | 30.000 | 64.657 | 0.7333 |

Failures are symmetric in `logitp`.

The same clipping creates a spurious plateau in the mean direction. For 12 values of `mean/n` in `[0.86, 0.995]` at `n = 100`, the number of reverse-mode gradient components below `1e-10` is:

| nu | components < 1e-10 |
|---:|--------------------:|
| 4  | 0 / 12 |
| 8  | 2 / 12 |
| 12 | 6 / 12 |
| 15 | 10 / 12 |
| 30 | 12 / 12 |

At `nu = 30`, the largest component is `2.2e-16`. Central finite differences agree with the returned function.

### Fix

Start from a scaled initial value, expand outward until the root is actually bracketed, and only then run safeguarded Newton iteration.

`E[Y | logitp]` is strictly increasing from 0 to `n`, so a finite root exists for every `0 < mean < n`.

Expansion is one-sided: only the endpoint that must move is reevaluated.

The interval-width exit is removed. With a verified bracket it is no longer needed as a safeguard, and it bypasses the derivative correction below. The solver now exits only through residual convergence or `iter_max`.

### After

All 120 cells are correct, with worst error in `mean/n` of `2.55e-14`.

At

```text
n = 100
nu = 15
mean / n = 0.97
```

`logitp` changes from a pinned `30.000` with gradient `1.19e-15` to `50.319` with gradient `5.56`, matching central finite differences to five digits.

No tested gradient component remains below `1e-10`.

## 2. Early convergence returns the derivative of the starting value

Independent of the bracket problem, the solver tests the residual before performing a Newton correction.

If the initial value is already the root, it therefore returns the derivative carried by `x0` rather than the implicit derivative of the solved root.

This occurs exactly at `nu = 1`, where

```text
logitp = logit(mean / n)
```

is the exact root.

The correct derivative is

```text
d(logitp) / d(nu)
  = -Cov(Y, lchoose(n, Y)) / Var(Y).
```

Before the fix:

| n | mean/n | AD before | finite diff / truth |
|---:|-------:|----------:|--------------------:|
| 20  | 0.75 | 1.09861 | 1.02808 |
| 20  | 0.90 | 2.19722 | 1.94022 |
| 100 | 0.75 | 1.09861 | 1.08516 |
| 100 | 0.90 | 2.19722 | 2.15186 |
| 100 | 0.99 | 4.59512 | 4.02570 |

At `nu = 0.999` and `1.001`, the gradient is correct; the defect occurs only at exact initial convergence.

This matters because `nu = 1` is the binomial reference point and is a natural starting or fixed value.

### Fix

Apply one Newton correction at convergence.

If

```text
r(x, nu) = E[Y | x, nu] - mean
```

and numerically `r = 0`, then

```text
x_new = x - r / r_x
```

leaves the root value unchanged but gives

```text
dx_new / dnu
  = dx / dnu - (r_nu + r_x * dx / dnu) / r_x
  = -r_nu / r_x,
```

so the starting derivative cancels and the implicit derivative is recovered.

After the change, AD agrees with both finite differences and the closed form at every tested point.

For example:

```text
n = 20
mean / n = 0.90
nu = 1

logitp:
returned       2.1972245773
expected       2.1972245773

d(logitp)/dnu:
AD             1.940221
finite diff    1.940221
closed form    1.940221
```

## Cost

On 252 ordinary cells satisfying

```text
nu * |logit(mean / n)| < 30
```

the scaled start reduces Newton iterations from `5.27` to `3.99`.

One-sided expansion adds `0.92` plain `calc_mean` evaluations on average, maximum 2. Since Newton evaluations carry derivatives while expansion evaluations do not, net cost is close to unchanged.

## Scope

The fixed-bracket failure is confined in these tests to strongly underdispersed, near-boundary cases.

In the interior,

```text
Var / Var_binomial ~= 1 / nu,
```

so `nu = 8` is about 87.5% and `nu = 15` about 93.3% of the way to the correlation floor `-1/(m-1)`.

`nu < 0` was unaffected over the tested range. For any finite `nu`, however, the root still diverges as the target mean approaches 0 or `n`, which the new expansion handles.

The second defect has different scope: it occurs at exact initial convergence, including the ordinary binomial reference point `nu = 1`.

## Validation

The patched header was compiled through downstream templates instantiating

```text
variable<1,2>
variable<2,2>
variable<3,2>
```

so the nested-AD paths used by `TMB_BIND_ATOMIC` are exercised.

A wider sweep covered 1232 cells spanning

```text
n        in [5, 1000]
nu       in [-20, 60]
mean / n in [0.001, 0.999]
```

with:

```text
failures:            0
worst mean/n error:  9.0e-13
NaN:                 0
iteration-cap hits:  0
```

Every solve therefore exited through residual convergence and received the final Newton correction.

At `nu = 1`, AD agrees with both central finite differences and the closed-form derivative. In the strong-underdispersion gradient test, no component falls below `1e-10` for `nu` in `{4, 8, 12, 15, 30}`.

`R CMD INSTALL` does not exercise the changed code because these headers are compiled only when instantiated by downstream templates.

## Downstream

The old bracket constant is compiled into existing glmmTMB binaries through `dcombinom2`.

Updating TMB alone therefore does not repair an already installed glmmTMB binary; glmmTMB must be rebuilt against the patched headers.